### PR TITLE
sk-4: Connect backend and frontend together

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,13 +5,26 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   preview: {
+    proxy: { "/steam":   {
+        target: "http://127.0.0.1:5000/",
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      }
+    },
     port: 3000,
     strictPort: true,
    },
    server: {
+    proxy: { "/steam":   {
+        target: "http://localhost:5000/",
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      }
+    },
     port: 3000,
     strictPort: true,
     host: true,
-    // origin: "http://0.0.0.0:3000", for some reason, this causes images to not load because of [[Failed to load resource: net::ERR_ADDRESS_INVALID]]
    },
 })


### PR DESCRIPTION
Add a proxy server so that API calls with "/steam/*" URL on the frontend get redirected to the backend. 

Screenshot below shows a successful API call to /steam/user/games/{ID}
![image](https://github.com/user-attachments/assets/fc8c0b40-d8c0-4638-be11-6fd87a1e1b99)

Screenshot of the response preview:
![image](https://github.com/user-attachments/assets/b5cde02c-fa2a-4fc0-86fb-d417bc76a292)
